### PR TITLE
Apply centralized training config to FlowerTune

### DIFF
--- a/flowertune_1b_v1/dataset.py
+++ b/flowertune_1b_v1/dataset.py
@@ -50,13 +50,24 @@ def formatting(dataset):
 
 
 def reformat(dataset, llm_task):
-    """Reformat datasets."""
-    dataset = dataset.rename_column("output", "response")
-    if llm_task in ["finance", "code"]:
+    """Reformat datasets to have `instruction`, `input` and `response` columns."""
+
+    # Some datasets (e.g. databricks/databricks-dolly-15k) use "context" as the
+    # input column.
+    if "context" in dataset.column_names:
+        dataset = dataset.rename_column("context", "input")
+
+    # The Code Alpaca dataset uses "output" as the response column.
+    if "output" in dataset.column_names:
+        dataset = dataset.rename_column("output", "response")
+
+    if llm_task in ["finance", "code"] and "input" in dataset.column_names:
         dataset = dataset.map(formatting, remove_columns=["input"])
-    if llm_task == "medical":
+
+    if llm_task == "medical" and "input" in dataset.column_names:
         dataset = dataset.remove_columns(["instruction"])
         dataset = dataset.rename_column("input", "instruction")
+
     return dataset
 
 

--- a/flowertune_1b_v1/models.py
+++ b/flowertune_1b_v1/models.py
@@ -54,7 +54,7 @@ def get_model(model_cfg: DictConfig):
     peft_config = LoraConfig(
         r=model_cfg.lora.peft_lora_r,
         lora_alpha=model_cfg.lora.peft_lora_alpha,
-        lora_dropout=0.075,
+        lora_dropout=model_cfg.lora.get("peft_lora_dropout", 0.075),
         task_type="CAUSAL_LM",
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,32 +32,39 @@ serverapp = "flowertune_1b_v1.server_app:app"
 clientapp = "flowertune_1b_v1.client_app:app"
 
 [tool.flwr.app.config]
-model.name = "mistralai/Mistral-7B-v0.3"
+model.name = "meta-llama/Llama-3.2-1B"
 model.quantization = 4
 model.gradient-checkpointing = true
-model.lora.peft-lora-r = 32
-model.lora.peft-lora-alpha = 64
+model.lora.peft-lora-r = 8
+model.lora.peft-lora-alpha = 16
+model.lora.peft-lora-dropout = 0.1
 train.save-every-round = 5
-train.learning-rate-max = 5e-5
+train.learning-rate-max = 3e-5
 train.learning-rate-min = 1e-6
-train.seq-length = 512
+train.seq-length = 1024
 train.training-arguments.output-dir = ""
 train.training-arguments.learning-rate = ""
-train.training-arguments.per-device-train-batch-size = 16
-train.training-arguments.gradient-accumulation-steps = 1
+train.training-arguments.per-device-train-batch-size = 8
+train.training-arguments.gradient-accumulation-steps = 2
 train.training-arguments.logging-steps = 10
-train.training-arguments.num-train-epochs = 3
+train.training-arguments.num-train-epochs = 10
 train.training-arguments.max-steps = 10
 train.training-arguments.save-steps = 1000
 train.training-arguments.save-total-limit = 10
 train.training-arguments.gradient-checkpointing = true
-train.training-arguments.lr-scheduler-type = "constant"
+train.training-arguments.lr-scheduler-type = "cosine"
 strategy.fraction-fit = 0.2
 strategy.fraction-evaluate = 0.0
 num-server-rounds = 200
 
+[tool.flwr.app.config.wandb]
+use-wandb = false
+project = "centralized-llm-categoty"
+run-name-prefix = "client"
+entity = ""
+
 [tool.flwr.app.config.static]
-dataset.name = "flwrlabs/code-alpaca-20k"
+dataset.name = "databricks/databricks-dolly-15k"
 
 [tool.flwr.federations]
 default = "local-simulation"


### PR DESCRIPTION
## Summary
- adjust dataset reformatting to support Dolly format
- allow configurable LoRA dropout
- update pyproject hyperparameters and dataset to match centralized training setup
- add per-client wandb runs

## Testing
- `python -m py_compile centralized_train.py flowertune_1b_v1/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846bf1015cc832fa900b24879fdc014